### PR TITLE
[gradle-profiler] bump dependency to latest OpenJDK

### DIFF
--- a/Formula/g/gradle-profiler.rb
+++ b/Formula/g/gradle-profiler.rb
@@ -11,7 +11,8 @@ class GradleProfiler < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "efaeffff25c03add41a89b4b1b7fcde8be147afd96baae57366787ffa9ba5c90"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "ee98c908d6a53450edcc507a6492b2ab8ea024ac455ab49c5baca51cc8c327d1"
   end
 
   depends_on "openjdk"

--- a/Formula/g/gradle-profiler.rb
+++ b/Formula/g/gradle-profiler.rb
@@ -14,22 +14,19 @@ class GradleProfiler < Formula
     sha256 cellar: :any_skip_relocation, all: "efaeffff25c03add41a89b4b1b7fcde8be147afd96baae57366787ffa9ba5c90"
   end
 
-  # gradle currently does not support Java 17 (ARM)
-  # gradle@6 is still default gradle-version, but does not support Java 16
-  # Switch to `openjdk` once above situations are no longer true
-  depends_on "openjdk@11"
+  depends_on "openjdk"
 
   def install
     rm(Dir["bin/*.bat"])
     libexec.install %w[bin lib]
-    env = Language::Java.overridable_java_home_env("11")
+    env = Language::Java.overridable_java_home_env
     (bin/"gradle-profiler").write_env_script libexec/"bin/gradle-profiler", env
   end
 
   test do
     (testpath/"settings.gradle").write ""
     (testpath/"build.gradle").write 'println "Hello"'
-    output = shell_output("#{bin}/gradle-profiler --gradle-version 7.0 --profile chrome-trace")
-    assert_includes output, "* Results written to"
+    output = shell_output("#{bin}/gradle-profiler --gradle-version 8.11 --profile chrome-trace")
+    assert_includes output, "* Writing results to"
   end
 end


### PR DESCRIPTION
Hi 👋🏻 

I need to `gradle-profiler` but I don't like that it needlessly installs the old `openjdk@11`. The comments I found in the formula source are no longer true as of now, so I think it's fine to bump to `openjdk`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
